### PR TITLE
Migrate to mcp 2.x (MCPServer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,16 +143,15 @@ authorization through : DJANGO_MCP_AUTHENTICATION_CLASSES
 You can test it with the python mcp SDK :
 
 ```python
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp import ClientSession
 
 
 async def main():
     # Connect to a streamable HTTP server
-    async with streamablehttp_client("http://localhost:8000/mcp") as (
+    async with streamable_http_client("http://localhost:8000/mcp") as (
         read_stream,
         write_stream,
-        _,
     ):
         # Create a session using the client streams
         async with ClientSession(read_stream, write_stream) as session:
@@ -278,7 +277,7 @@ class MyTools(MCPToolset):
 
 ### Use low level mcp server annotation
 
-You can import the DjangoMCP server instance and use FastMCP annotations to declare
+You can import the DjangoMCP server instance and use MCPServer annotations to declare
 mcp tools and resources :
 
 ```python

--- a/mcp_server/djangomcp.py
+++ b/mcp_server/djangomcp.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import QuerySet
 from django.http import HttpResponse, HttpRequest
-from mcp.server import FastMCP
+from mcp.server import MCPServer
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from rest_framework.mixins import CreateModelMixin, UpdateModelMixin, DestroyModelMixin, ListModelMixin
 from rest_framework.serializers import Serializer
@@ -161,11 +161,12 @@ MCP_SESSION_ID_HDR = "Mcp-Session-Id"
 
 # FIXME: shall I reimplement the necessary without the
 # Stuff pulled to support embedded server ?
-class DjangoMCP(FastMCP):
+class DjangoMCP(MCPServer):
 
     def __init__(self, name=None, instructions=None, stateless=False):
         # Prevent extra server settings as we do not use the embedded server
-        super().__init__(name or "django_mcp_server", instructions)
+        # instructions must be keyword-only: in mcp 2.x the second positional is title
+        super().__init__(name or "django_mcp_server", instructions=instructions)
         self.stateless = stateless
         engine = import_module(settings.SESSION_ENGINE)
         self.SessionStore = engine.SessionStore
@@ -173,7 +174,7 @@ class DjangoMCP(FastMCP):
         # Optionally publish a tool that returns the global server instructions
         if getattr(settings, "DJANGO_MCP_GET_SERVER_INSTRUCTIONS_TOOL", True):
             async def _get_server_instructions():
-                return self._mcp_server.instructions or ""
+                return self._lowlevel_server.instructions or ""
 
             self._tool_manager.add_tool(
                 fn=_get_server_instructions,
@@ -184,8 +185,8 @@ class DjangoMCP(FastMCP):
     @property
     def session_manager(self) -> StreamableHTTPSessionManager:
         return StreamableHTTPSessionManager(
-            app=self._mcp_server,
-            event_store=self._event_store,
+            app=self._lowlevel_server,
+            event_store=None,
             json_response=True,
             stateless=True,  # Sessions will be managed as Django sessions.
         )
@@ -231,12 +232,12 @@ class DjangoMCP(FastMCP):
         Append instructions to the server instructions.
         This method is called by the Django view when a request is received.
         """
-        inst = self._mcp_server.instructions
+        inst = self._lowlevel_server.instructions
         if not inst:
             inst = new_instructions
         else:
             inst = inst.strip() + "\n\n" + new_instructions.strip()
-        self._mcp_server.instructions = inst
+        self._lowlevel_server.instructions = inst
 
     def register_mcptoolset(self, toolset):
         return toolset._add_tools_to(self._tool_manager)

--- a/mcp_server/management/commands/mcp_inspect.py
+++ b/mcp_server/management/commands/mcp_inspect.py
@@ -17,10 +17,10 @@ async def _check_client():
     svr_wr, cl_rd = anyio.create_memory_object_stream(0)
 
     async def run_server():
-        await mcp_server._mcp_server.run(
+        await mcp_server._lowlevel_server.run(
             svr_rd,
             svr_wr,
-            mcp_server._mcp_server.create_initialization_options(),
+            mcp_server._lowlevel_server.create_initialization_options(),
         )
 
     async def run_client():
@@ -31,7 +31,7 @@ async def _check_client():
             tool_list = await session.list_tools()
             for tool in tool_list.tools:
                 print(f'\n\t{tool.name}: {tool.description}')
-                print(f'\tParameters: {tool.inputSchema}')
+                print(f'\tParameters: {tool.input_schema}')
 
             print("Resources discovered in server:")
             resource_list = await session.list_resources()

--- a/mcp_server/query_tool.py
+++ b/mcp_server/query_tool.py
@@ -613,7 +613,7 @@ class _QueryExecutor:
                     type="resource",
                     resource=TextResourceContents(
                         uri=f"resource://query_result/{renderer.format}",
-                        mimeType=renderer.media_type,
+                        mime_type=renderer.media_type,
                         text=ret
                     )
                 )]
@@ -622,7 +622,7 @@ class _QueryExecutor:
                     type="resource",
                     resource=BlobResourceContents(
                         uri=f"resource://query_result/{renderer.format}",
-                        mimeType=renderer.media_type,
+                        mime_type=renderer.media_type,
                         blob=base64.b64encode(ret).decode('utf-8')
                     )
                 )]

--- a/mcp_server/views.py
+++ b/mcp_server/views.py
@@ -1,10 +1,6 @@
-from django.conf import settings
 from django.http import HttpResponse
-from django.shortcuts import render
 from django.utils.decorators import method_decorator
-from django.views import View
 from django.views.decorators.csrf import csrf_exempt
-from mcp.server import FastMCP
 from rest_framework.views import APIView
 
 from mcp_server.djangomcp import global_mcp_server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-mcp-server"
-version = "0.5.6"
+version = "0.6.0"
 description = "Django MCP Server is a Django extensions to easily enable AI Agents to interact with Django Apps through the Model Context Protocol it works equally well on WSGI and ASGI"
 authors = [
     {name = "Omar BENHAMID",email = "omar.benhamid@smart-gts.com"}
@@ -13,7 +13,7 @@ documentation = "https://github.com/omarbenhamid/django-mcp-server"
 keywords = ["django", "mcp", "model context protocol", "tools"]
 requires-python = ">=3.10"
 dependencies = [
-    "mcp (>=1.8.0)",
+    "mcp (>=2.0.0,<3)",
     "django (>=4.0)",
     "djangorestframework (>=3.15.0)",
     "inflection (>=0.5.1,<0.6.0)",

--- a/test/test_mcp_client.py
+++ b/test/test_mcp_client.py
@@ -1,13 +1,12 @@
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp import ClientSession
 
 
 async def main():
     # Connect to a streamable HTTP server
-    async with streamablehttp_client("http://localhost:8000/mcpunsecured") as (
+    async with streamable_http_client("http://localhost:8000/mcpunsecured") as (
         read_stream,
         write_stream,
-        _,
     ):
         # Create a session using the client streams
         async with ClientSession(read_stream, write_stream) as session:

--- a/test/test_mcp_server.py
+++ b/test/test_mcp_server.py
@@ -1,13 +1,10 @@
 from typing import Any
 import httpx
-from mcp.server import Server
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 
-# Initialize FastMCP server
-mcp = FastMCP("weather")
-
-Server
+# Initialize MCPServer
+mcp = MCPServer("weather")
 
 # Constants
 NWS_API_BASE = "https://api.weather.gov"
@@ -96,8 +93,6 @@ Forecast: {period['detailedForecast']}
 
 if __name__ == "__main__":
     # Initialize and run the server
-    #mcp.run(transport='sse')
+    # mcp.run(transport='sse')
     # mcp.run(transport='stdio')
-    mcp.settings.port = 8002
-    mcp.settings.json_response = True
-    mcp.run(transport='streamable-http')
+    mcp.run(transport='streamable-http', port=8002, json_response=True)


### PR DESCRIPTION
## Summary
- Require `mcp (>=2.0.0,<3)` and bump package to `0.6.0` so fresh installs no longer pull an incompatible mcp 2.x against FastMCP-based code.
- Migrate `DjangoMCP` from removed `FastMCP` to `MCPServer`, including keyword `instructions=`, `_lowlevel_server`, and session manager construction.
- Update inspect command, query resource mime types, client samples, and README for the mcp 2.x API surface.

## Test plan
- [x] Fresh install with `mcp==2.0.0`; Django `manage.py check` succeeds (no `ImportError: FastMCP`)
- [x] Example `bird_counter` tests pass (8)
- [x] Streamable HTTP: initialize → tools/list → `get_species_count` via `/mcpunsecured`
- [ ] Confirm consumers drop any temporary `mcp<2` pin when upgrading to this release


Made with [Cursor](https://cursor.com)